### PR TITLE
Add wandb episode video logging

### DIFF
--- a/src/environments/reference_model_multi_agent.py
+++ b/src/environments/reference_model_multi_agent.py
@@ -451,8 +451,12 @@ class ReferenceModel(MultiAgentEnv):
 
         return action_mask
 
-    def render(self):
-        """Render the environment."""
+    def render(self, return_array: bool = False):
+        """Render the environment.
+
+        Args:
+            return_array: If True, return the RGB image of the current figure.
+        """
         if not hasattr(self, "fig") or self.fig is None:
             # Initialize the rendering environment if it hasn't been done yet
             plt.ion()
@@ -556,6 +560,13 @@ class ReferenceModel(MultiAgentEnv):
         # Redraw the updated plot
         self.fig.canvas.draw()
         self.fig.canvas.flush_events()
+
+        if return_array:
+            frame = np.frombuffer(self.fig.canvas.tostring_rgb(), dtype=np.uint8)
+            frame = frame.reshape(
+                self.fig.canvas.get_width_height()[::-1] + (3,)
+            )
+            return frame
 
         return True
 

--- a/src/environments/reference_model_single_agent.py
+++ b/src/environments/reference_model_single_agent.py
@@ -379,8 +379,12 @@ class ReferenceModel(gym.Env):
 
         return action_mask
 
-    def render(self):
-        """Render the environment."""
+    def render(self, return_array: bool = False):
+        """Render the environment.
+
+        Args:
+            return_array: If True, return the RGB image of the current figure.
+        """
         if not hasattr(self, "fig") or self.fig is None:
             # Initialize the rendering environment if it hasn't been done yet
             plt.ion()
@@ -472,6 +476,13 @@ class ReferenceModel(gym.Env):
         # Redraw the updated plot
         self.fig.canvas.draw()
         self.fig.canvas.flush_events()
+
+        if return_array:
+            frame = np.frombuffer(self.fig.canvas.tostring_rgb(), dtype=np.uint8)
+            frame = frame.reshape(
+                self.fig.canvas.get_width_height()[::-1] + (3,)
+            )
+            return frame
 
         return True
 

--- a/src/trainers/tuner.py
+++ b/src/trainers/tuner.py
@@ -7,6 +7,8 @@ from ray import air, tune
 # from ray.tune.search.bayesopt import BayesOptSearch
 from ray.air.integrations.wandb import WandbLoggerCallback
 
+from .video_callback import VideoCallback
+
 
 def tune_with_callback(config, algo_name, env_name):
     """
@@ -46,7 +48,8 @@ def tune_with_callback(config, algo_name, env_name):
                     # project=f"{env_name}-comparison",
                     dir=os.path.abspath("./experiments"),
                     group=f"{algo_name}-{config['env_config']['training_execution_mode']}",
-                )
+                ),
+                VideoCallback(),
             ],
         ),
     )

--- a/src/trainers/video_callback.py
+++ b/src/trainers/video_callback.py
@@ -1,0 +1,31 @@
+import numpy as np
+import wandb
+from ray.rllib.algorithms.callbacks import DefaultCallbacks
+
+
+class VideoCallback(DefaultCallbacks):
+    """Callback that logs a rendered episode as a video to wandb."""
+
+    def __init__(self, record_interval: int = 100):
+        super().__init__()
+        self.record_interval = record_interval
+
+    def on_train_result(self, *, algorithm, result, **kwargs):
+        if result["training_iteration"] % self.record_interval != 0:
+            return
+
+        env = algorithm.workers.local_worker().env
+        frames = []
+        obs, _ = env.reset()
+        done = {"__all__": False}
+        while not done["__all__"]:
+            actions = {
+                a: algorithm.compute_single_action(o, explore=False)
+                for a, o in obs.items()
+            }
+            obs, _, done, _, _ = env.step(actions)
+            frames.append(env.render(return_array=True))
+
+        video = np.stack(frames)
+        wandb.log({"episode_video": wandb.Video(video, fps=4, format="mp4")})
+


### PR DESCRIPTION
## Summary
- extend env render methods to optionally return image arrays
- create `VideoCallback` that logs a rendered episode
- register callback in `tune_with_callback`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688b61bff6f0832581fb1ba0ad37d4c6